### PR TITLE
bacon: Revert multiple A2DP sample rate change

### DIFF
--- a/audio/audio_policy.conf
+++ b/audio/audio_policy.conf
@@ -89,7 +89,7 @@ audio_hw_modules {
   a2dp {
     outputs {
       a2dp {
-        sampling_rates 44100|48000
+        sampling_rates 44100
         channel_masks AUDIO_CHANNEL_OUT_STEREO
         formats AUDIO_FORMAT_PCM_16_BIT
         devices AUDIO_DEVICE_OUT_ALL_A2DP


### PR DESCRIPTION
 * Stick with 44.1KHz on this hardware for now- the HAL is not always
   passing the config to the hardware. Revert until it's debugged.

Change-Id: I855480e7d0c5d5fbf964b423b59c3a73a062c92d